### PR TITLE
Add a function for weak-modules

### DIFF
--- a/kmods-via-containers
+++ b/kmods-via-containers
@@ -35,6 +35,17 @@ get_container_context() {
         fi
 }
 
+# Use weak modules to set up symlinks, assuming kABI compatibility
+# Requires KO_FILES be set, for example with something like
+# KO_FILES=$(find /lib/modules/*/extra/kmod-name -type f | grep .ko)
+weak_modules_add() {
+    if [ ! -z "$KO_FILES" ]; then
+        echo "$KO_FILES" | weak-modules --add-modules --verbose --no-initramfs
+    else
+        echo "weak_modules_add requires KO_FILES to be set to contain the required .ko files, one per line"
+    fi
+}
+
 # Check if the module only uses whitelisted symbols
 kabi_check_module() {
     LIBM="/lib/modules"


### PR DESCRIPTION
This PR will add a function to KVC to run the weak-modules tool which sets up the necessary symlinks for kernel modules that are kABI compatible (whitelisted symbols only) but built against a different kernel version than the one running on the host. 

The function depends on an environment variable to be set which contains the filenames and locations of all of the .ko files needed to load the kernel module. How this environment variable is created is going to be up to the user of the framework, but an example of how it can be used which I tested is in

An example of how this can be used is in https://github.com/openshift-psap/kvc-lustre-client/blob/9a72e636280d608b809f36bff9cea3a16998faa0/lustre-client-lib.sh#L133