### PR TITLE
Changing the default runtime from 'podman' to 'kubernetes'.

### DIFF
--- a/kmods-via-containers.conf
+++ b/kmods-via-containers.conf
@@ -3,4 +3,4 @@
 # and deliver kernel modules via container builds/images.
 
 # The container runtime to use for building/executing containers
-KVC_CONTAINER_RUNTIME=podman
+KVC_CONTAINER_RUNTIME=kubernetes


### PR DESCRIPTION
We only use KVC to load the already built driver and we do it from
inside OCP, therefore, the default value should refer to OCP and not to
running it locally using podman.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>